### PR TITLE
Message length boost fixes

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatBottomView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatBottomView.swift
@@ -38,9 +38,7 @@ protocol ChatBottomViewDelegate : AnyObject {
     ///Sending message
     func shouldSendMessage(text: String, price: Int, completion: @escaping (Bool) -> ())
     func shouldMainChatOngoingMessage()
-    
-    func getThreadUUID() -> String?
-    func getReplyUUID() -> String?
+    func isMessageLengthValid(text: String) -> Bool
 }
 
 class ChatBottomView: NSView, LoadableNib {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatMessageFieldView+FieldsExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatMessageFieldView+FieldsExtension.swift
@@ -31,40 +31,16 @@ extension ChatMessageFieldView : NSTextViewDelegate, MessageFieldDelegate {
             in: affectedCharRange,
             with: replacementString ?? ""
         )
-        
-        let effectiveThreadUUID = delegate?.getThreadUUID()
-        let effectiveReplyUUID = delegate?.getReplyUUID()
-        
-        return isMessageWithinByteLimit(
-            message: currentChangedString,
-            replyUUID: effectiveReplyUUID,
-            threadUUID: effectiveThreadUUID
-        )
-    }
-    
-    func isMessageWithinByteLimit(
-        message: String,
-        replyUUID: String? = nil,
-        threadUUID: String? = nil,
-        byteLimit: Int = 869
-    ) -> Bool {
-        var totalMessage = message
-        
-        if let replyUUID = replyUUID {
-            totalMessage += replyUUID + "--------" //add padding to account for additional payload introduced by replyUUID
-        }
-        
-        if let threadUUID = threadUUID {
-            totalMessage += threadUUID + "-----------" //add padding to account for additional payload introduced by threadUUID
-        }
-        
-        return totalMessage.byteSize() <= byteLimit
+                
+        return delegate?.isMessageLengthValid(text: currentChangedString) ?? true
     }
     
     func shouldSendMessage() {
         if sendButton.isEnabled {
+            let text = messageTextView.string.trim()
+            
             delegate?.shouldSendMessage(
-                text: messageTextView.string.trim(),
+                text: text,
                 price: Int(priceTextField.stringValue) ?? 0,
                 completion: { success in
                     if !success {
@@ -72,6 +48,7 @@ extension ChatMessageFieldView : NSTextViewDelegate, MessageFieldDelegate {
                             title: "generic.error.title".localized,
                             message: "generic.message.error".localized
                         )
+                        self.messageTextView.string = text
                     }
                 }
             )

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
@@ -209,7 +209,8 @@ extension NewChatViewController : ChatBottomViewDelegate {
             
             if let attachmentObject = attachmentObject {
                 newChatViewModel.insertProvisionalAttachmentMessageAndUpload(
-                    attachmentObject: attachmentObject, chat: chat
+                    attachmentObject: attachmentObject, 
+                    chat: chat
                 )
             } else {
                 messageBubbleHelper.showGenericMessageView(
@@ -411,12 +412,17 @@ extension NewChatViewController : ChatBottomViewDelegate {
         chatCollectionView.scrollToBottom(animated: false)
     }
     
-    func getThreadUUID() -> String? {
-        return self.newChatViewModel.replyingTo?.uuid
-    }
-    
-    func getReplyUUID() -> String? {
-        return self.threadUUID ?? self.newChatViewModel.replyingTo?.replyUUID
+    func isMessageLengthValid(
+        text: String
+    ) -> Bool {
+        let sendingAttachment = draggingView.isSendingMedia()
+        
+        return SphinxOnionManager.sharedInstance.isMessageLengthValid(
+            text: text,
+            sendingAttachment: sendingAttachment,
+            threadUUID: self.newChatViewModel.replyingTo?.uuid,
+            replyUUID: self.threadUUID ?? self.newChatViewModel.replyingTo?.replyUUID
+        )
     }
 }
 

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+CollectionViewExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+CollectionViewExtension.swift
@@ -171,6 +171,8 @@ extension NewChatViewController : NewChatTableDataSourceDelegate {
         if isAtBottom {
             shouldScrollToBottom()
         }
+        
+        setMessageFieldActive()
     }
     
     func shouldPayInvoiceFor(messageId: Int) {


### PR DESCRIPTION
- Message length validation improved
- Fix for boost failing and not being sent on tribes
- Setting focus on message field when replying
- Setting text again in message field if it fails