### PR TITLE
Fix overlapping UI buttons

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Payments/Views/Base.lproj/Payments.storyboard
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Payments/Views/Base.lproj/Payments.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,21 +27,21 @@
                                 </textFieldCell>
                             </textField>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="gc5-Pf-cC8">
-                                <rect key="frame" x="50" y="322" width="300" height="300"/>
+                                <rect key="frame" x="41" y="303" width="319" height="319"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="300" id="6Ch-GV-jHV"/>
+                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="319" id="9b1-BF-TTq"/>
                                     <constraint firstAttribute="width" secondItem="gc5-Pf-cC8" secondAttribute="height" multiplier="1:1" id="x5U-Rh-D6r"/>
                                 </constraints>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="extraIcon" id="066-dH-VQL"/>
                             </imageView>
                             <box boxType="custom" borderType="line" borderWidth="4" cornerRadius="5" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="K4J-Rs-G8d">
-                                <rect key="frame" x="155" y="450" width="91" height="45"/>
+                                <rect key="frame" x="153" y="440" width="95" height="45"/>
                                 <view key="contentView" id="HvC-xI-9kH">
-                                    <rect key="frame" x="4" y="4" width="83" height="37"/>
+                                    <rect key="frame" x="4" y="4" width="87" height="37"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FWE-w8-fVb">
-                                            <rect key="frame" x="2" y="0.0" width="79" height="37"/>
+                                            <rect key="frame" x="2" y="0.0" width="83" height="37"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" title="PAID" id="I2h-0d-nky">
                                                 <font key="font" size="30" name="Montserrat-Bold"/>
                                                 <color key="textColor" name="PrimaryGreen"/>
@@ -62,7 +62,10 @@
                                 <color key="fillColor" name="Body"/>
                             </box>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LId-FC-mhF">
-                                <rect key="frame" x="30" y="207" width="340" height="91"/>
+                                <rect key="frame" x="30" y="188" width="340" height="91"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="91" id="XPb-BY-eNK"/>
+                                </constraints>
                                 <textFieldCell key="cell" alignment="center" id="wNu-2z-sZt">
                                     <font key="font" size="11" name="Roboto-Regular"/>
                                     <string key="title">Receive Invoice Details
@@ -176,6 +179,7 @@ Receive Invoice Details</string>
                             <constraint firstItem="K4J-Rs-G8d" firstAttribute="centerX" secondItem="gc5-Pf-cC8" secondAttribute="centerX" id="Hkv-y2-8ZW"/>
                             <constraint firstItem="quZ-Sv-9fI" firstAttribute="top" secondItem="tOy-S4-hL0" secondAttribute="top" constant="20" id="SVK-JP-Gg0"/>
                             <constraint firstItem="qkc-tl-sN7" firstAttribute="leading" secondItem="tOy-S4-hL0" secondAttribute="leading" constant="32" id="cLL-t8-SP9"/>
+                            <constraint firstItem="qkc-tl-sN7" firstAttribute="top" secondItem="LId-FC-mhF" secondAttribute="bottom" constant="24" id="e2o-9R-MRn"/>
                             <constraint firstItem="quZ-Sv-9fI" firstAttribute="centerX" secondItem="gc5-Pf-cC8" secondAttribute="centerX" id="ey9-5s-i9j"/>
                             <constraint firstItem="4HU-9Q-GFs" firstAttribute="top" secondItem="2KP-Os-n7a" secondAttribute="bottom" constant="12" id="jEw-LF-Jbd"/>
                             <constraint firstItem="4HU-9Q-GFs" firstAttribute="leading" secondItem="qkc-tl-sN7" secondAttribute="leading" id="m1G-uC-0YE"/>


### PR DESCRIPTION
Fix UI to buttons don't overlap invoice string when making Sphinx window shorter. QR code image view should be resized so all elements fit in the view