### PR TITLE
Wrong title on popup view when adding new contacts

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Contacts/View Controllers/AddFriendViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Contacts/View Controllers/AddFriendViewController.swift
@@ -36,6 +36,7 @@ class AddFriendViewController: NSViewController {
         advanceTo(
             vc: inviteVC,
             identifier: "new-invite-window",
+            title: "New To Sphinx",
             height: 600
         )
     }
@@ -48,17 +49,19 @@ class AddFriendViewController: NSViewController {
         
         advanceTo(
             vc: contactVC,
-            identifier: "new-contact-window"
+            identifier: "new-contact-window",
+            title: "Already On Sphinx"
         )
     }
     
     func advanceTo(
         vc: NSViewController,
         identifier: String,
+        title: String = "Contacts".localized,
         height: CGFloat? = nil
     ) {
         WindowsManager.sharedInstance.showOnCurrentWindow(
-            with: "Contact".localized,
+            with: title.localized,
             identifier: identifier,
             contentVC: vc,
             hideDivider: true,


### PR DESCRIPTION
Change title from Contact to New to Sphinx and Already on Sphinx on each of the views accessed from New Contact view so they represent the action that is being performed