### PR TITLE
feat(core-data): add timezone attributes

### DIFF
--- a/com.stakwork.sphinx.desktop/CoreData/Chat/Chat+CoreDataProperties.swift
+++ b/com.stakwork.sphinx.desktop/CoreData/Chat/Chat+CoreDataProperties.swift
@@ -42,7 +42,10 @@ extension Chat {
     @NSManaged public var pinnedMessageUUID: String?
     @NSManaged public var isTribeICreated: Bool
     @NSManaged public var secondBrainUrl: String?
-    
+    @NSManaged public var timezoneEnabled: Bool
+    @NSManaged public var timezoneIdentifier: String?
+    @NSManaged public var remoteTimezoneIdentifier: String?
+    @NSManaged public var timezoneUpdated: Bool
     @NSManaged public var messages: NSSet?
     @NSManaged public var subscription: Subscription?
     @NSManaged public var contentFeed: ContentFeed?

--- a/com.stakwork.sphinx.desktop/CoreData/TransactionMessage/TransactionMessage+CoreDataProperties.swift
+++ b/com.stakwork.sphinx.desktop/CoreData/TransactionMessage/TransactionMessage+CoreDataProperties.swift
@@ -44,7 +44,7 @@ extension TransactionMessage {
     @NSManaged public var push: Bool
     @NSManaged public var errorMessage: String?
     @NSManaged public var tag: String?
-    
+    @NSManaged public var remoteTimezoneIdentifier: String?
     @NSManaged public var mediaKey: String?
     @NSManaged public var mediaType: String?
     @NSManaged public var mediaToken: String?

--- a/com.stakwork.sphinx.desktop/CoreData/com_stakwork_sphinx_desktop.xcdatamodeld/.xccurrentversion
+++ b/com.stakwork.sphinx.desktop/CoreData/com_stakwork_sphinx_desktop.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>com_stakwork_sphinx_desktop 3.xcdatamodel</string>
+	<string>com_stakwork_sphinx_desktop 4.xcdatamodel</string>
 </dict>
 </plist>

--- a/com.stakwork.sphinx.desktop/CoreData/com_stakwork_sphinx_desktop.xcdatamodeld/com_stakwork_sphinx_desktop 4.xcdatamodel/contents
+++ b/com.stakwork.sphinx.desktop/CoreData/com_stakwork_sphinx_desktop.xcdatamodeld/com_stakwork_sphinx_desktop 4.xcdatamodel/contents
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="ActionTrack" representedClassName="ActionTrack" syncable="YES">
+        <attribute name="metaData" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uploaded" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Chat" representedClassName="Chat" syncable="YES">
+        <attribute name="contactIds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" defaultDateTimeInterval="599540400" usesScalarValueType="NO"/>
+        <attribute name="escrowAmount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="groupKey" optional="YES" attributeType="String"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isTribeICreated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="muted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="myAlias" optional="YES" attributeType="String"/>
+        <attribute name="myPhotoUrl" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="notify" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ownerPubkey" optional="YES" attributeType="String"/>
+        <attribute name="pendingContactIds" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer"/>
+        <attribute name="photoUrl" optional="YES" attributeType="String"/>
+        <attribute name="pin" optional="YES" attributeType="String"/>
+        <attribute name="pinnedMessageUUID" optional="YES" attributeType="String"/>
+        <attribute name="pricePerMessage" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="priceToJoin" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="privateTribe" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="remoteTimezoneIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="secondBrainUrl" optional="YES" attributeType="String"/>
+        <attribute name="seen" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timezoneEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="timezoneIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="unlisted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <attribute name="webAppLastDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="contentFeed" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ContentFeed" inverseName="chat" inverseEntity="ContentFeed"/>
+        <relationship name="lastMessage" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TransactionMessage" inverseName="lastMessageChat" inverseEntity="TransactionMessage"/>
+        <relationship name="messages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TransactionMessage" inverseName="chat" inverseEntity="TransactionMessage"/>
+        <relationship name="subscription" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Subscription" inverseName="chat" inverseEntity="Subscription"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+                <constraint value="ownerPubkey"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="ContentFeed" representedClassName="ContentFeed" syncable="YES">
+        <attribute name="authorName" optional="YES" attributeType="String"/>
+        <attribute name="datePublished" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="feedDescription" optional="YES" attributeType="String"/>
+        <attribute name="feedID" optional="YES" attributeType="String"/>
+        <attribute name="feedKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="feedURL" optional="YES" attributeType="URI"/>
+        <attribute name="generator" optional="YES" attributeType="String"/>
+        <attribute name="imageURL" optional="YES" attributeType="URI"/>
+        <attribute name="language" optional="YES" attributeType="String"/>
+        <attribute name="linkURL" optional="YES" attributeType="URI"/>
+        <attribute name="mediaKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="ownerURL" optional="YES" attributeType="URI"/>
+        <attribute name="subscribed" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="contentFeed" inverseEntity="Chat"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ContentFeedItem" inverseName="contentFeed" inverseEntity="ContentFeedItem"/>
+        <relationship name="paymentDestinations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ContentFeedPaymentDestination" inverseName="feed" inverseEntity="ContentFeedPaymentDestination"/>
+        <relationship name="paymentModel" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ContentFeedPaymentModel" inverseName="feed" inverseEntity="ContentFeedPaymentModel"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="ContentFeedItem" representedClassName="ContentFeedItem" syncable="YES">
+        <attribute name="authorName" optional="YES" attributeType="String"/>
+        <attribute name="datePublished" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="enclosureKind" optional="YES" attributeType="String"/>
+        <attribute name="enclosureURL" optional="YES" attributeType="URI"/>
+        <attribute name="feedKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="imageURL" optional="YES" attributeType="URI"/>
+        <attribute name="itemDescription" optional="YES" attributeType="String"/>
+        <attribute name="itemID" optional="YES" attributeType="String"/>
+        <attribute name="linkURL" optional="YES" attributeType="URI"/>
+        <attribute name="mediaKindValue" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <relationship name="contentFeed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContentFeed" inverseName="items" inverseEntity="ContentFeed"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="itemID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="ContentFeedPaymentDestination" representedClassName="ContentFeedPaymentDestination" syncable="YES">
+        <attribute name="address" optional="YES" attributeType="String"/>
+        <attribute name="customKey" optional="YES" attributeType="String"/>
+        <attribute name="customValue" optional="YES" attributeType="String"/>
+        <attribute name="split" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="feed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContentFeed" inverseName="paymentDestinations" inverseEntity="ContentFeed"/>
+    </entity>
+    <entity name="ContentFeedPaymentModel" representedClassName="ContentFeedPaymentModel" syncable="YES">
+        <attribute name="suggestedBTC" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <relationship name="feed" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContentFeed" inverseName="paymentModel" inverseEntity="ContentFeed"/>
+    </entity>
+    <entity name="LSat" representedClassName="LSat" syncable="YES">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="identifier" attributeType="String" defaultValueString=""/>
+        <attribute name="issuer" optional="YES" attributeType="String"/>
+        <attribute name="macaroon" attributeType="String" defaultValueString=""/>
+        <attribute name="metadata" optional="YES" attributeType="String"/>
+        <attribute name="paths" optional="YES" attributeType="String"/>
+        <attribute name="paymentRequest" attributeType="String" defaultValueString=""/>
+        <attribute name="preimage" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="identifier"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Server" representedClassName="Server" syncable="YES">
+        <attribute name="ip" optional="YES" attributeType="String"/>
+        <attribute name="pubKey" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Subscription" representedClassName="Subscription" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="count" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="cron" optional="YES" attributeType="String"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="ended" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="endNumber" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paused" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="subscription" inverseEntity="Chat"/>
+        <relationship name="contact" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserContact" inverseName="subscriptions" inverseEntity="UserContact"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="TransactionMessage" representedClassName="TransactionMessage" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="amountMsat" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" defaultDateTimeInterval="599540400" usesScalarValueType="NO"/>
+        <attribute name="date" optional="YES" attributeType="Date" defaultDateTimeInterval="599540400" usesScalarValueType="NO"/>
+        <attribute name="encrypted" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="errorMessage" optional="YES" attributeType="String"/>
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="invoice" optional="YES" attributeType="String"/>
+        <attribute name="mediaFileName" optional="YES" attributeType="String"/>
+        <attribute name="mediaFileSize" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="mediaKey" optional="YES" attributeType="String"/>
+        <attribute name="mediaToken" optional="YES" attributeType="String"/>
+        <attribute name="mediaType" optional="YES" attributeType="String"/>
+        <attribute name="messageContent" optional="YES" attributeType="String"/>
+        <attribute name="muid" optional="YES" attributeType="String"/>
+        <attribute name="originalMuid" optional="YES" attributeType="String"/>
+        <attribute name="paymentHash" optional="YES" attributeType="String"/>
+        <attribute name="push" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="receiverId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="recipientAlias" optional="YES" attributeType="String"/>
+        <attribute name="recipientPic" optional="YES" attributeType="String"/>
+        <attribute name="remoteTimezoneIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="replyUUID" optional="YES" attributeType="String"/>
+        <attribute name="seen" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="senderAlias" optional="YES" attributeType="String"/>
+        <attribute name="senderId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="senderPic" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="tag" optional="YES" attributeType="String"/>
+        <attribute name="threadUUID" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <relationship name="chat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="messages" inverseEntity="Chat"/>
+        <relationship name="lastMessageChat" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Chat" inverseName="lastMessage" inverseEntity="Chat"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="UserContact" representedClassName="UserContact" syncable="YES">
+        <attribute name="avatarUrl" optional="YES" attributeType="String"/>
+        <attribute name="contactKey" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" defaultDateTimeInterval="599540400" usesScalarValueType="NO"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="fromGroup" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="index" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isOwner" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="nickname" optional="YES" attributeType="String"/>
+        <attribute name="nodeAlias" optional="YES" attributeType="String"/>
+        <attribute name="phoneNumber" optional="YES" attributeType="String"/>
+        <attribute name="pin" optional="YES" attributeType="String"/>
+        <attribute name="privatePhoto" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publicKey" optional="YES" attributeType="String"/>
+        <attribute name="routeHint" optional="YES" attributeType="String"/>
+        <attribute name="scid" optional="YES" attributeType="String"/>
+        <attribute name="sentInviteCode" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeZone" optional="YES" attributeType="String"/>
+        <attribute name="tipAmount" optional="YES" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <relationship name="invite" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UserInvite" inverseName="contact" inverseEntity="UserInvite"/>
+        <relationship name="subscriptions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Subscription" inverseName="contact" inverseEntity="Subscription"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="UserInvite" representedClassName="UserInvite" syncable="YES">
+        <attribute name="inviteString" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="status" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="welcomeMessage" optional="YES" attributeType="String"/>
+        <relationship name="contact" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="UserContact" inverseName="invite" inverseEntity="UserContact"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="inviteString"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+</model>

--- a/sphinx.xcodeproj/project.pbxproj
+++ b/sphinx.xcodeproj/project.pbxproj
@@ -1576,6 +1576,7 @@
 		47FEE22A2A66F76E00646C4E /* NewOnlyTextMessageCollectionViewitem+DelegateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewOnlyTextMessageCollectionViewitem+DelegateExtension.swift"; sourceTree = "<group>"; };
 		47FEE22D2A6710F500646C4E /* NewChatViewController+CollectionViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewChatViewController+CollectionViewExtension.swift"; sourceTree = "<group>"; };
 		5EA81AB599AD947A8862A100 /* Pods-Sphinx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sphinx.debug.xcconfig"; path = "Target Support Files/Pods-Sphinx/Pods-Sphinx.debug.xcconfig"; sourceTree = "<group>"; };
+		77CFCEB92D7F3FCD008B2BB7 /* com_stakwork_sphinx_desktop 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "com_stakwork_sphinx_desktop 4.xcdatamodel"; sourceTree = "<group>"; };
 		82C242433501D81263FED4C2 /* Pods_Sphinx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sphinx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		931083BE2BE0271B00D03EC9 /* TribeMembersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TribeMembersViewController.swift; sourceTree = "<group>"; };
 		934082782BC8827700FD7E34 /* DashboardPresenterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPresenterViewController.swift; sourceTree = "<group>"; };
@@ -5545,11 +5546,12 @@
 		4734D3992417E3D400D6957E /* com_stakwork_sphinx_desktop.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				77CFCEB92D7F3FCD008B2BB7 /* com_stakwork_sphinx_desktop 4.xcdatamodel */,
 				473873AF2CD929C400CBBC28 /* com_stakwork_sphinx_desktop 3.xcdatamodel */,
 				47DF91502C4AA27E00E8128A /* com_stakwork_sphinx_desktop 2.xcdatamodel */,
 				4734D39A2417E3D400D6957E /* com_stakwork_sphinx_desktop.xcdatamodel */,
 			);
-			currentVersion = 473873AF2CD929C400CBBC28 /* com_stakwork_sphinx_desktop 3.xcdatamodel */;
+			currentVersion = 77CFCEB92D7F3FCD008B2BB7 /* com_stakwork_sphinx_desktop 4.xcdatamodel */;
 			path = com_stakwork_sphinx_desktop.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;


### PR DESCRIPTION
This PR adds new timezone attributes and enables migration for the Core Data model.

### Changes Made
- **New Model Version:** Created a new Core Data model version (4).
- **Chat Entity Updates:**  
  - Added attributes:
    - `timezoneEnabled` (Bool, default: true)
    - `timezoneIdentifier` (String, default: null)
    - `remoteTimezoneIdentifier` (String, default: null)
    - `timezoneUpdated` (Bool, default: true)
- **TransactionMessage Entity Updates:**  
  - Added attribute:
    - `remoteTimezoneIdentifier` (String, default: nil)
- **NSManagedObject Subclasses:** Updated `Chat+CoreDataProperties.swift` and `TransactionMessage+CoreDataProperties.swift` accordingly.

### Verification
- Built the app on the **develop** branch.
- Ran the new feature version over the existing data store with no issues or crashes.