### PR TITLE
Fix replyUUID miscalculation and loss in message send and confirmation on Mac

### DIFF
--- a/com.stakwork.sphinx.desktop/Crypter/SphinxOnionManager/SphinxOnionManager+ChatExtension.swift
+++ b/com.stakwork.sphinx.desktop/Crypter/SphinxOnionManager/SphinxOnionManager+ChatExtension.swift
@@ -609,6 +609,15 @@ extension SphinxOnionManager {
         
         localMsg.senderId = owner?.id ?? UserData.sharedInstance.getUserId(context: backgroundContext)
 
+        // Preserve replyUUID from inner content if the local message doesn't already have one
+        if localMsg.replyUUID == nil,
+           let msg = message.message,
+           let innerContent = MessageInnerContent(JSONString: msg),
+           let replyUuid = innerContent.replyUuid
+        {
+            localMsg.replyUUID = replyUuid
+        }
+
         return localMsg
     }
 

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+BottomTopBarsExtension.swift
@@ -461,7 +461,7 @@ extension NewChatViewController : ChatBottomViewDelegate {
             text: text,
             sendingAttachment: chatBottomView.isSendingMedia(),
             threadUUID: self.newChatViewModel.replyingTo?.uuid,
-            replyUUID: self.threadUUID ?? self.newChatViewModel.replyingTo?.replyUUID,
+            replyUUID: self.threadUUID ?? self.newChatViewModel.replyingTo?.uuid,
             metaDataString: chat?.getMetaDataJsonStringValue(forceIncludeTimezone: self.newChatViewModel.wasTimezoneNotSentRecently())
         )
         


### PR DESCRIPTION
Generated with Hive: Fix replyUUID miscalculation and loss in message send and confirmation on Mac