### PR TITLE
Generated with Hive: Fix macOS mic indicator not clearing after LiveKit disconnect and voice recording

### DIFF
--- a/com.stakwork.sphinx.desktop/Helpers/Audio/AudioRecorderHelper.swift
+++ b/com.stakwork.sphinx.desktop/Helpers/Audio/AudioRecorderHelper.swift
@@ -164,6 +164,7 @@ class AudioRecorderHelper : NSObject, @unchecked Sendable {
     func recordingDidFail() {
         state = .None
         audioRecorder?.stop()
+        audioRecorder = nil
         let d = delegate
         Task { @MainActor in d?.didStartRecording(false) }
     }
@@ -171,6 +172,7 @@ class AudioRecorderHelper : NSObject, @unchecked Sendable {
     func finishRecording(success: Bool) {
         if let _ = audioRecorder {
             audioRecorder?.stop()
+            audioRecorder = nil
 
             recordingTimer?.invalidate()
             recordingTimer = nil

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/ConnectView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/ConnectView.swift
@@ -147,9 +147,5 @@ struct ConnectView: View {
             }
         }
         .frame(minWidth: 500, minHeight: 500)
-        .alert(isPresented: $roomCtx.shouldShowDisconnectReason) {
-            Alert(title: Text("Disconnected"),
-                  message: Text("Reason: " + String(describing: roomCtx.latestError)))
-        }
     }
 }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/RoomContext.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/RoomContext.swift
@@ -40,10 +40,7 @@ final class RoomContext: NSObject, ObservableObject, @unchecked Sendable {
 
     private let store: ValueStore<Preferences>
 
-    // Used to show connection error dialog
-    // private var didClose: Bool = false
-    @Published var shouldShowDisconnectReason: Bool = false
-    public var latestError: LiveKitError?
+
 
     public var room: Room!
 
@@ -254,6 +251,9 @@ final class RoomContext: NSObject, ObservableObject, @unchecked Sendable {
     }
 
     func disconnect() async {
+        if room.connectionState == .connected {
+            try? await room.localParticipant.setMicrophone(enabled: false)
+        }
         await room.disconnect()
     }
 
@@ -344,26 +344,7 @@ extension RoomContext: RoomDelegate {
         print("Did update connectionState \(oldValue) -> \(connectionState)")
 
         if case .disconnected = connectionState {
-            if let error = room.disconnectError {
-                if error.type == .cancelled {
-                    onCallEnded?()
-                } else {
-                    latestError = room.disconnectError
-
-                    Task.detached { @MainActor [weak self] in
-                        guard let self else { return }
-                        self.shouldShowDisconnectReason = true
-                        // Reset state
-                        self.focusParticipant = nil
-                        self.textFieldString = ""
-                        self.showMessagesView = false
-                        self.messages.removeAll()
-                        // self.objectWillChange.send()
-                    }
-                }
-            } else {
-                onCallEnded?()
-            }
+            onCallEnded?()
         }
         
         if case .connected = connectionState {


### PR DESCRIPTION
Fix macOS mic indicator not clearing after LiveKit disconnect and voice recording