### PR TITLE
Pass route_hint from webview keysend to SphinxOnionManager

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/WebApps/Helper/WebAppHelper.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/WebApps/Helper/WebAppHelper.swift
@@ -299,9 +299,12 @@ extension WebAppHelper : WKScriptMessageHandler {
                 self.sendKeySendResponse(dict: dict, success: false)
                 return
             }
-            
+
+            let routeHint = dict["route_hint"] as? String
+
             SphinxOnionManager.sharedInstance.keysend(
                 pubkey: dest,
+                routeHint: routeHint,
                 amt: Double(amt)
             ) { success in
                 if success {


### PR DESCRIPTION
The KEYSEND bridge handler was dropping route_hint, causing keysend failures for nodes behind an LSP.