### PR TITLE
Fix maxMessageIndex corruption in Mac offline message sync

### DIFF
--- a/com.stakwork.sphinx.desktop/Crypter/SphinxOnionManager/SphinxOnionManager+AccountRestoreExtension.swift
+++ b/com.stakwork.sphinx.desktop/Crypter/SphinxOnionManager/SphinxOnionManager+AccountRestoreExtension.swift
@@ -358,8 +358,6 @@ extension SphinxOnionManager {
         msgCountLimit: Int,
         reverse: Bool
     ) {
-        startWatchdogTimer()
-        
         let safeLastMsgIndex = max(lastMessageIndex, 0)
         
         do {
@@ -999,9 +997,6 @@ extension SphinxOnionManager {
         
         endWatchdogTime()
         resetFromRestore()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-            self?.syncNewMessages()
-        }
     }
     
     func finishMessagesFetch(
@@ -1022,7 +1017,7 @@ extension SphinxOnionManager {
         resetFromRestore()
         updateRoutingInfo()
         
-        if isRestore, let maxIndex = TransactionMessage.getMaxIndex() {
+        if let maxIndex = TransactionMessage.getMaxIndex() {
             maxMessageIndex = maxIndex
         }
     }

--- a/com.stakwork.sphinx.desktop/Crypter/SphinxOnionManager/SphinxOnionManager+AccountRestoreExtension.swift
+++ b/com.stakwork.sphinx.desktop/Crypter/SphinxOnionManager/SphinxOnionManager+AccountRestoreExtension.swift
@@ -1017,7 +1017,7 @@ extension SphinxOnionManager {
         resetFromRestore()
         updateRoutingInfo()
         
-        if let maxIndex = TransactionMessage.getMaxIndex() {
+        if isRestore, let maxIndex = TransactionMessage.getMaxIndex() {
             maxMessageIndex = maxIndex
         }
     }


### PR DESCRIPTION
Generated with Hive: Fix maxMessageIndex corruption in Mac offline message sync