### PR TITLE
Generated with Hive: Replace ObservedObject with StateObject to prevent screen share picker flicker

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/ScreenShareSourcePickerView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/ScreenShareSourcePickerView.swift
@@ -102,7 +102,7 @@ struct ScreenShareSourcePickerView: View {
     }
 
     let onPickScreenShareSource: OnPickScreenShareSource?
-    @ObservedObject var ctrl = ScreenShareSourcePickerCtrl()
+    @StateObject private var ctrl = ScreenShareSourcePickerCtrl()
 
     private var columns = [
         GridItem(.fixed(250)),


### PR DESCRIPTION
Replace ObservedObject with StateObject to prevent screen share picker flicker