### PR TITLE
Fix avatar reuse bug in tribe chat message bubbles

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Collection View Items/New Chat View/NewOnlyTextMessageCollectionViewItem/NewOnlyTextMessageCollectionViewitem.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Collection View Items/New Chat View/NewOnlyTextMessageCollectionViewItem/NewOnlyTextMessageCollectionViewitem.swift
@@ -40,6 +40,11 @@ class NewOnlyTextMessageCollectionViewitem: CommonNewMessageCollectionViewitem, 
     @IBOutlet weak var receivedMessageMenuButton: CustomButton!
     
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        chatAvatarView.resetView()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Collection View Items/New Chat View/Thread Collection View Item/ThreadCollectionViewItem.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Collection View Items/New Chat View/Thread Collection View Item/ThreadCollectionViewItem.swift
@@ -79,6 +79,11 @@ class ThreadCollectionViewItem: CommonNewMessageCollectionViewitem, ChatCollecti
     @IBOutlet weak var labelHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var lastReplyLabelHeightConstraint: NSLayoutConstraint!
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        chatAvatarView.resetView()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/ChatSmallAvatarView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Custom Views/ChatSmallAvatarView.swift
@@ -129,6 +129,7 @@ class ChatSmallAvatarView: NSView, LoadableNib {
         self.delegate = delegate
         
         profileImageView.sd_cancelCurrentImageLoad()
+        imageUrl = nil
         profileImageView.radius = radius ?? profileImageView.frame.height / 2
         
         showInitials(


### PR DESCRIPTION
Generated with Hive: Fix avatar reuse bug in tribe chat message bubbles