### PR TITLE
Generated with Hive: Extend log retention to 72 hours on Mac

### DIFF
--- a/com.stakwork.sphinx.desktop/Managers/Logging/AppLogger.swift
+++ b/com.stakwork.sphinx.desktop/Managers/Logging/AppLogger.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-private let kLogRetentionHours: Double = 24
+private let kLogRetentionHours: Double = 72
 
 final class AppLogger: @unchecked Sendable {
 


### PR DESCRIPTION
Extend log retention to 72 hours on Mac