### PR TITLE
Fix JoinVideoCallView layout by correcting participant row height constant

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Video Call/JoinVideoCallView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Video Call/JoinVideoCallView.swift
@@ -29,7 +29,7 @@ class JoinVideoCallView: NSView, @preconcurrency LoadableNib {
     
     static let kViewHeight: CGFloat = 206
     static let kViewAudioOnlyHeight: CGFloat = 158
-    static let kParticipantsRowHeight: CGFloat = 60
+    static let kParticipantsRowHeight: CGFloat = 70
     
     private let participantsCountLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Video Call/JoinVideoCallView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Video Call/JoinVideoCallView.swift
@@ -29,7 +29,7 @@ class JoinVideoCallView: NSView, @preconcurrency LoadableNib {
     
     static let kViewHeight: CGFloat = 206
     static let kViewAudioOnlyHeight: CGFloat = 158
-    static let kParticipantsRowHeight: CGFloat = 70
+    static let kParticipantsRowHeight: CGFloat = 60
     
     private let participantsCountLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Video Call/ParticipantBoxView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Video Call/ParticipantBoxView.swift
@@ -47,7 +47,7 @@ class ParticipantBoxView: NSView {
     
     private func setupViews() {
         wantsLayer = true
-        layer?.backgroundColor = NSColor.Sphinx.Body.withAlphaComponent(0.08).cgColor
+        layer?.backgroundColor = NSColor.Sphinx.Text.withAlphaComponent(0.05).cgColor
         layer?.cornerRadius = 8
         
         translatesAutoresizingMaskIntoConstraints = false
@@ -66,7 +66,7 @@ class ParticipantBoxView: NSView {
             nameLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 4),
             
             widthAnchor.constraint(equalToConstant: 42),
-            heightAnchor.constraint(equalToConstant: 60)
+            heightAnchor.constraint(equalToConstant: 50)
         ])
         
         avatarImageView.wantsLayer = true


### PR DESCRIPTION
Generated with Hive: Fix JoinVideoCallView layout by correcting participant row height constant