### PR TITLE
Fix stale audio routing after headphone unplug and call rejoin

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/AppContext.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/AppContext.swift
@@ -121,6 +121,15 @@ final class AppContext: ObservableObject {
         AudioManager.shared.onDeviceUpdate = nil
     }
     
+    func syncWithSystemAudioDefaults() {
+        let systemOutput = AudioManager.shared.defaultOutputDevice
+        let systemInput = AudioManager.shared.defaultInputDevice
+        print("AudioDevice sync — output: \(systemOutput.name), input: \(systemInput.name)")
+        outputDevice = systemOutput
+        inputDevice = systemInput
+        reloadAudioDevices()
+    }
+
     func reloadAudioDevices() {
         //Audio Output device
         var defaultOutputDevice = outputDevice

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/RoomContextView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Live Kit/Views/RoomContextView.swift
@@ -91,12 +91,12 @@ struct RoomContextView: View {
             .foregroundColor(Color.white)
             .onDisappear {
                 print("\(String(describing: type(of: self))) onDisappear")
-                AudioManager.shared.onDeviceUpdate = nil
                 Task {
                     await roomCtx.disconnect()
                 }
             }
             .onAppear() {
+                appCtx.syncWithSystemAudioDefaults()
                 Task {
                     if !roomCtx.token.isEmpty {
                         do {


### PR DESCRIPTION
Generated with Hive: Fix stale audio routing after headphone unplug and call rejoin