### PR TITLE
Fix participant deduplication and add delayed empty-name refresh in Mac live call banner

### DIFF
--- a/com.stakwork.sphinx.desktop/API/API+LiveKitExtension.swift
+++ b/com.stakwork.sphinx.desktop/API/API+LiveKitExtension.swift
@@ -115,6 +115,41 @@ extension API {
         task.resume()
     }
     
+    func getCallParticipants(
+        roomName: String,
+        callback: @escaping ([BubbleMessageLayoutState.CallParticipantInfo]) -> Void,
+        errorCallback: ((String) -> Void)? = nil
+    ) {
+        let url = "\(self.kVideoCallServer)/api/participants?roomName=\(roomName.urlEncode() ?? roomName)"
+        let request: URLRequest? = createRequest(url, params: nil, method: "GET")
+        guard let request = request else {
+            errorCallback?("Error creating request")
+            callback([])
+            return
+        }
+        sphinxRequest(request) { response in
+            switch response.result {
+            case .success(let data):
+                let json = JSON(data)
+                var participants: [BubbleMessageLayoutState.CallParticipantInfo] = []
+                for (_, item) in json {
+                    let name = item["nickname"].stringValue
+                    guard !name.isEmpty else { continue }
+                    participants.append(BubbleMessageLayoutState.CallParticipantInfo(
+                        identity: name,
+                        name: name,
+                        profilePictureUrl: item["avatarUrl"].string,
+                        isActive: true
+                    ))
+                }
+                callback(participants)
+            case .failure(let error):
+                errorCallback?(error.localizedDescription)
+                callback([])
+            }
+        }
+    }
+
     func removeParticipant(
         room: String,
         participantIdentity: String,

--- a/com.stakwork.sphinx.desktop/Managers/CallParticipantsSocket/CallParticipantsSocketManager.swift
+++ b/com.stakwork.sphinx.desktop/Managers/CallParticipantsSocket/CallParticipantsSocketManager.swift
@@ -55,6 +55,10 @@ class CallParticipantsSocketManager: NSObject, WebSocketDelegate, @unchecked Sen
             sendSubscribe(roomName: roomName)
         }
     }
+    
+    func sendSubscribeTo(roomName: String) {
+        sendSubscribe(roomName: roomName)
+    }
 
     func unsubscribe(roomName: String) {
         sendUnsubscribe(roomName: roomName)

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource+CellDelegateExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource+CellDelegateExtension.swift
@@ -1309,11 +1309,13 @@ extension NewChatTableDataSource: CallParticipantsSocketDelegate {
     }
 
     private func refreshParticipants(for roomName: String) {
-        API.sharedInstance.getCallParticipants(roomName: roomName) { [weak self] fresh in
-            guard let self = self, !fresh.isEmpty else { return }
-            self.callParticipantsStore[roomName] = fresh
-            self.reloadCellsForRoom(roomName)
-        }
+        callParticipantsSocketManager?.sendSubscribeTo(roomName: roomName)
+        
+//        API.sharedInstance.getCallParticipants(roomName: roomName) { [weak self] fresh in
+//            guard let self = self, !fresh.isEmpty else { return }
+//            self.callParticipantsStore[roomName] = fresh
+//            self.reloadCellsForRoom(roomName)
+//        }
     }
 
     func participantLeft(roomName: String, identity: String) {

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource+CellDelegateExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource+CellDelegateExtension.swift
@@ -1295,9 +1295,25 @@ extension NewChatTableDataSource: CallParticipantsSocketDelegate {
 
     func participantJoined(roomName: String, participant: BubbleMessageLayoutState.CallParticipantInfo) {
         var current = callParticipantsStore[roomName] ?? []
+        // Dedup: ignore if this identity is already tracked
+        guard !current.contains(where: { $0.identity == participant.identity }) else { return }
         current.append(participant)
         callParticipantsStore[roomName] = current
         reloadCellsForRoom(roomName)
+        // LiveKit may not have resolved the display name yet — refresh after 2s
+        if participant.name.isEmpty {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                self?.refreshParticipants(for: roomName)
+            }
+        }
+    }
+
+    private func refreshParticipants(for roomName: String) {
+        API.sharedInstance.getCallParticipants(roomName: roomName) { [weak self] fresh in
+            guard let self = self, !fresh.isEmpty else { return }
+            self.callParticipantsStore[roomName] = fresh
+            self.reloadCellsForRoom(roomName)
+        }
     }
 
     func participantLeft(roomName: String, identity: String) {


### PR DESCRIPTION
Generated with Hive: Fix participant deduplication and add delayed empty-name refresh in Mac live call banner