### PR TITLE
Fix active call banner state refresh and enforce single call window

### DIFF
--- a/com.stakwork.sphinx.desktop/Extensions/Notification.Name.swift
+++ b/com.stakwork.sphinx.desktop/Extensions/Notification.Name.swift
@@ -53,4 +53,6 @@ extension Notification.Name {
     
     static let onWebAppLinkTapped = Notification.Name("onWebAppLinkTapped")
     static let onWebAppNavigationChanged = Notification.Name("onWebAppNavigationChanged")
+    
+    static let liveKitCallWindowDidChange = Notification.Name("liveKitCallWindowDidChange")
 }

--- a/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
+++ b/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
@@ -90,6 +90,15 @@ import SwiftUI
         }).last as? TaggedWindow
     }
     
+    func closeActiveCallWindow() {
+        guard let callWindow = getLiveKitCallWindow(),
+              let identifier = callWindow.windowIdentifier else { return }
+        openedWindowIdentifiers.removeAll(where: { $0 == identifier })
+        hideCallControlWindow(forceClose: true)
+        closeIfExists(identifier: identifier)
+        NotificationCenter.default.post(name: .liveKitCallWindowDidChange, object: nil)
+    }
+    
     func getCenteredFrameFor(size: CGSize) -> CGRect {
         let mainScreen = NSScreen.main
         let centerPoint = CGPoint(x: ((mainScreen?.frame.width ?? 1000) / 2) - (size.width / 2), y: ((mainScreen?.frame.height ?? 735) / 2) - (size.height / 2))
@@ -579,11 +588,13 @@ import SwiftUI
                                     self.openedWindowIdentifiers.removeAll(where: { $0 == linkUrl })
                                     self.hideCallControlWindow(forceClose: true)
                                     self.closeIfExists(identifier: link)
+                                    NotificationCenter.default.post(name: .liveKitCallWindowDidChange, object: nil)
                                 }
                         }).environmentObject(appCtx).environmentObject(roomCtx)
                         
                         let hostingController = NSHostingController(rootView: roomContextView)
                         self.presentWindowForCallVC(vc: hostingController, link: link, delegate: roomCtx)
+                        NotificationCenter.default.post(name: .liveKitCallWindowDidChange, object: nil)
                     }
                 },
                 errorCallback: { error in

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
@@ -24,6 +24,10 @@ extension NewChatViewController: ActiveCallBannerDelegate {
             stack.topAnchor.constraint(equalTo: chatTopView.bottomAnchor),
         ])
         // No fixed height — stack self-sizes via each row's intrinsicContentSize
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleCallWindowChange),
+            name: .liveKitCallWindowDidChange, object: nil
+        )
     }
     
     // MARK: - WebSocket-based banner lifecycle
@@ -73,12 +77,28 @@ extension NewChatViewController: ActiveCallBannerDelegate {
         if isViewLoaded {
             chatTopView?.hideAllCallBanners()
         }
+        NotificationCenter.default.removeObserver(self, name: .liveKitCallWindowDidChange, object: nil)
     }
     
     // MARK: - ActiveCallBannerDelegate
 
     func didTapJoin(callLink: String) {
+        WindowsManager.sharedInstance.closeActiveCallWindow()
         shouldStartCallWith(link: callLink, audioOnly: false, isHost: false)
+    }
+    
+    // MARK: - Call window change notification
+    
+    @objc private func handleCallWindowChange() {
+        refreshAllBanners()
+    }
+    
+    private func refreshAllBanners() {
+        for roomName in liveCallRooms.keys {
+            let participants = chatTableDataSource?.callParticipantsStore[roomName] ?? []
+            guard !participants.isEmpty else { continue }
+            shouldUpdateLiveCallBanner(roomName: roomName, participants: participants)
+        }
     }
 
     func didTapOpen() {


### PR DESCRIPTION
Generated with Hive: Fix active call banner state refresh and enforce single call window