### PR TITLE
Generated with Hive: Fix live-call banner not updating for new calls and preserve observer lifecycle on Mac

### DIFF
--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatTopView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatTopView.swift
@@ -94,6 +94,15 @@ class ChatTopView: NSView, LoadableNib {
         }
     }
 
+    /// Fully removes the banner row for `roomName` from the stack and view hierarchy.
+    func removeCallBanner(roomName: String) {
+        guard let banner = bannerViews[roomName] else { return }
+        liveCallBannerStack.removeArrangedSubview(banner)
+        banner.removeFromSuperview()
+        bannerViews.removeValue(forKey: roomName)
+        if bannerViews.isEmpty { liveCallBannerStack.isHidden = true }
+    }
+
     /// Hides the row for `roomName`; collapses the stack if all rows are hidden.
     func hideCallBanner(roomName: String) {
         bannerViews[roomName]?.isHidden = true

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource+ResultsControllerExtension.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource+ResultsControllerExtension.swift
@@ -870,9 +870,8 @@ extension NewChatTableDataSource : @preconcurrency NSFetchedResultsControllerDel
 
                     if let lastMessage = self.messagesArray.last, lastMessage.isCallLink() {
                         if lastMessage.id != self.lastSeenCallMessageId {
-                            let wasFirstLoad = self.lastSeenCallMessageId == nil
                             self.lastSeenCallMessageId = lastMessage.id
-                            if !wasFirstLoad {
+                            if self.hasDoneInitialCallBannerSetup {
                                 DispatchQueue.main.async { self.delegate?.newCallMessageReceived() }
                             }
                         }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Data Source/New Chat Data Source/New Chat Table Data Source/NewChatTableDataSource.swift
@@ -116,6 +116,7 @@ class NewChatTableDataSource : NSObject {
     var bannerRooms: Set<String> = []
     var callParticipantsSocketManager: CallParticipantsSocketManager?
     var lastSeenCallMessageId: Int? = nil
+    var hasDoneInitialCallBannerSetup: Bool = false
     var uploadingProgress: [Int: MessageTableCellState.UploadProgressData] = [:]
     var replyViewAdditionalHeight: [Int: CGFloat] = [:]
     var rowHeightCache: [String: CGFloat] = [:]  // Cache for row heights

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
@@ -24,10 +24,6 @@ extension NewChatViewController: ActiveCallBannerDelegate {
             stack.topAnchor.constraint(equalTo: chatTopView.bottomAnchor),
         ])
         // No fixed height — stack self-sizes via each row's intrinsicContentSize
-        NotificationCenter.default.addObserver(
-            self, selector: #selector(handleCallWindowChange),
-            name: .liveKitCallWindowDidChange, object: nil
-        )
     }
     
     // MARK: - WebSocket-based banner lifecycle
@@ -35,6 +31,13 @@ extension NewChatViewController: ActiveCallBannerDelegate {
     func startLiveCallBannerPolling() {
         guard chat?.isPublicGroup() == true, !isThread else { return }
         guard let chatId = chat?.id else { return }
+
+        chatTableDataSource?.hasDoneInitialCallBannerSetup = true
+        NotificationCenter.default.removeObserver(self, name: .liveKitCallWindowDidChange, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleCallWindowChange),
+            name: .liveKitCallWindowDidChange, object: nil
+        )
 
         installActiveCallBannerIfNeeded()
 
@@ -113,8 +116,52 @@ extension NewChatViewController {
     }
 
     func newCallMessageReceived() {
-        stopLiveCallBannerPolling()
-        startLiveCallBannerPolling()
+        guard chat?.isPublicGroup() == true, !isThread,
+              let chatId = chat?.id else { return }
+
+        // Recompute the current top-3 call rooms
+        var freshRooms: [String: String] = [:]
+        for msg in TransactionMessage.getRecentCallMessages(for: chatId, limit: 3) {
+            guard let raw = msg.messageContent else { continue }
+            let link: String?
+            if let parsed = VoIPRequestMessage.getFromString(raw)?.link, parsed.isCallLink {
+                link = parsed
+            } else if raw.isCallLink {
+                link = raw
+            } else {
+                link = nil
+            }
+            guard let link,
+                  let url = URL(string: link),
+                  let room = url.pathComponents.last(where: { !$0.isEmpty && $0 != "/" })
+            else { continue }
+            freshRooms[room] = link
+        }
+
+        // Remove rooms that fell out of the top-3
+        for room in Set(liveCallRooms.keys).subtracting(freshRooms.keys) {
+            chatTableDataSource?.subscribedRooms.remove(room)
+            chatTableDataSource?.bannerRooms.remove(room)
+            chatTableDataSource?.callParticipantsStore.removeValue(forKey: room)
+            chatTableDataSource?.callParticipantsSocketManager?.unsubscribe(roomName: room)
+            chatTopView.removeCallBanner(roomName: room)
+        }
+
+        // Subscribe to rooms newly entering the top-3
+        for (room, link) in freshRooms where liveCallRooms[room] == nil {
+            liveCallRooms[room] = link
+            if chatTableDataSource?.callParticipantsSocketManager == nil {
+                chatTableDataSource?.callParticipantsSocketManager = CallParticipantsSocketManager()
+                chatTableDataSource?.callParticipantsSocketManager?.delegate = chatTableDataSource
+            }
+            if chatTableDataSource?.subscribedRooms.contains(room) == false {
+                chatTableDataSource?.subscribedRooms.insert(room)
+                chatTableDataSource?.callParticipantsSocketManager?.subscribe(roomName: room)
+            }
+            chatTableDataSource?.bannerRooms.insert(room)
+        }
+
+        liveCallRooms = freshRooms
     }
 
     func shouldUpdateLiveCallBanner(roomName: String, participants: [BubbleMessageLayoutState.CallParticipantInfo]) {


### PR DESCRIPTION
Fix live-call banner not updating for new calls and preserve observer lifecycle on Mac