### PR TITLE
Fix live call banner auto-leave, rejoin subscription, join/open state, and date-ordered banner stack

### DIFF
--- a/com.stakwork.sphinx.desktop/CoreData/TransactionMessage/TransactionMessageQueriesExtension.swift
+++ b/com.stakwork.sphinx.desktop/CoreData/TransactionMessage/TransactionMessageQueriesExtension.swift
@@ -857,7 +857,7 @@ extension TransactionMessage {
 
     static func getRecentCallMessages(
         for chatId: Int,
-        limit: Int = 3,
+        limit: Int? = nil,
         context: NSManagedObjectContext = CoreDataManager.sharedManager.persistentContainer.viewContext
     ) -> [TransactionMessage] {
         let fetchRequest: NSFetchRequest<TransactionMessage> = TransactionMessage.fetchRequest()
@@ -867,7 +867,9 @@ extension TransactionMessage {
             TransactionMessage.TransactionMessageType.call.rawValue
         )
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "id", ascending: false)]
-        fetchRequest.fetchLimit = limit
+        if let limit = limit {
+            fetchRequest.fetchLimit = limit
+        }
         return (try? context.fetch(fetchRequest)) ?? []
     }
     

--- a/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
+++ b/com.stakwork.sphinx.desktop/Managers/Windows/WindowsManager.swift
@@ -552,6 +552,12 @@ import SwiftUI
         
         let linkUrl = VoIPRequestMessage.getFromString(link)?.link ?? link
         
+        // Auto-leave any existing call when joining a different room
+        if let existingRoom = getLiveKitCallWindow()?.windowIdentifier?.liveKitRoomName,
+           existingRoom != linkUrl.liveKitRoomName {
+            closeActiveCallWindow()
+        }
+        
         if openedWindowIdentifiers.contains(linkUrl) {
             return
         }

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatTopView.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/Custom Views/Chat View/ChatTopView.swift
@@ -49,23 +49,32 @@ class ChatTopView: NSView, LoadableNib {
         return sv
     }()
 
+    private struct ActiveCall {
+        let roomName: String
+        let messageDate: Date
+        var callLink: String
+        let banner: ActiveCallBannerView
+    }
+
+    /// All currently active calls sorted descending by messageDate (newest first).
+    private var activeCalls: [ActiveCall] = []
     private var bannerViews: [String: ActiveCallBannerView] = [:]
 
-    /// Creates or reuses the banner row for `roomName`, configures it, and makes it visible.
+    /// Creates or reuses the banner row for `roomName`, configures it, and keeps
+    /// the top-3-by-date active calls visible in newest-first order.
     func showCallBanner(
         roomName: String,
         participants: [BubbleMessageLayoutState.CallParticipantInfo],
         callLink: String,
+        messageDate: Date,
         isAlreadyInCall: Bool,
         delegate: ActiveCallBannerDelegate
     ) {
+        // Get or create the banner view
         let banner: ActiveCallBannerView
         if let existing = bannerViews[roomName] {
             banner = existing
         } else {
-            // Cap at 3 visible rows
-            let visibleCount = bannerViews.values.filter { !$0.isHidden }.count
-            guard visibleCount < 3 else { return }
             banner = ActiveCallBannerView()
             bannerViews[roomName] = banner
             liveCallBannerStack.addArrangedSubview(banner)
@@ -82,36 +91,55 @@ class ChatTopView: NSView, LoadableNib {
             delegate: delegate
         )
 
-        liveCallBannerStack.isHidden = false
+        // Upsert into activeCalls and re-sort descending by date (newest first)
+        if let idx = activeCalls.firstIndex(where: { $0.roomName == roomName }) {
+            activeCalls[idx] = ActiveCall(roomName: roomName, messageDate: messageDate, callLink: callLink, banner: banner)
+        } else {
+            activeCalls.append(ActiveCall(roomName: roomName, messageDate: messageDate, callLink: callLink, banner: banner))
+        }
+        activeCalls.sort { $0.messageDate > $1.messageDate }
 
-        if banner.isHidden {
-            banner.alphaValue = 0
-            banner.isHidden = false
-            NSAnimationContext.runAnimationGroup { ctx in
-                ctx.duration = 0.25
-                banner.animator().alphaValue = 1
+        // Trim to top 3; hide any overflow entries
+        if activeCalls.count > 3 {
+            for overflow in activeCalls[3...] {
+                overflow.banner.isHidden = true
             }
+            activeCalls = Array(activeCalls.prefix(3))
         }
+
+        rebuildBannerStack()
     }
 
-    /// Hides the row for `roomName`; collapses the stack if all rows are hidden.
+    /// Removes `roomName` from the active set and reorders the stack.
     func hideCallBanner(roomName: String) {
-        bannerViews[roomName]?.isHidden = true
-        if bannerViews.values.allSatisfy({ $0.isHidden }) {
-            liveCallBannerStack.isHidden = true
-        }
+        activeCalls.removeAll { $0.roomName == roomName }
+        rebuildBannerStack()
     }
 
-    /// Hides every banner row and collapses the stack.
+    /// Hides every banner row, collapses the stack, and resets all state.
     func hideAllCallBanners() {
-        bannerViews.values.forEach { $0.isHidden = true }
+        activeCalls.removeAll()
         liveCallBannerStack.isHidden = true
-        // Remove all arranged subviews so the next chat starts clean
         for view in liveCallBannerStack.arrangedSubviews {
             liveCallBannerStack.removeArrangedSubview(view)
             view.removeFromSuperview()
         }
         bannerViews.removeAll()
+    }
+
+    /// Reorders the stack's arranged subviews to match `activeCalls` (newest first = top).
+    private func rebuildBannerStack() {
+        for (idx, call) in activeCalls.enumerated() {
+            liveCallBannerStack.removeArrangedSubview(call.banner)
+            liveCallBannerStack.insertArrangedSubview(call.banner, at: idx)
+            call.banner.isHidden = false
+        }
+        // Hide any banner views that are no longer in activeCalls
+        let activeRoomNames = Set(activeCalls.map { $0.roomName })
+        for (roomName, banner) in bannerViews where !activeRoomNames.contains(roomName) {
+            banner.isHidden = true
+        }
+        liveCallBannerStack.isHidden = activeCalls.isEmpty
     }
     
     // MARK: - Setup

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
@@ -57,6 +57,7 @@ extension NewChatViewController: ActiveCallBannerDelegate {
             }
 
             liveCallRooms[roomName] = callLink
+            liveCallRoomDates[roomName] = callMessage.date ?? Date()
 
             if chatTableDataSource?.callParticipantsSocketManager == nil {
                 chatTableDataSource?.callParticipantsSocketManager = CallParticipantsSocketManager()
@@ -65,6 +66,9 @@ extension NewChatViewController: ActiveCallBannerDelegate {
             if chatTableDataSource?.subscribedRooms.contains(roomName) == false {
                 chatTableDataSource?.subscribedRooms.insert(roomName)
                 chatTableDataSource?.callParticipantsSocketManager?.subscribe(roomName: roomName)
+            } else {
+                // Already subscribed — force the server to re-emit current_participants
+                chatTableDataSource?.callParticipantsSocketManager?.sendSubscribeTo(roomName: roomName)
             }
             chatTableDataSource?.bannerRooms.insert(roomName)
         }
@@ -74,6 +78,7 @@ extension NewChatViewController: ActiveCallBannerDelegate {
         chatTableDataSource?.unsubscribeAllRooms()
         chatTableDataSource?.bannerRooms.removeAll()
         liveCallRooms.removeAll()
+        liveCallRoomDates.removeAll()
         if isViewLoaded {
             chatTopView?.hideAllCallBanners()
         }
@@ -91,12 +96,16 @@ extension NewChatViewController: ActiveCallBannerDelegate {
     
     @objc private func handleCallWindowChange() {
         refreshAllBanners()
+        if WindowsManager.sharedInstance.getLiveKitCallWindow() != nil {
+            for roomName in chatTableDataSource?.bannerRooms ?? [] {
+                chatTableDataSource?.callParticipantsSocketManager?.sendSubscribeTo(roomName: roomName)
+            }
+        }
     }
     
     private func refreshAllBanners() {
         for roomName in liveCallRooms.keys {
             let participants = chatTableDataSource?.callParticipantsStore[roomName] ?? []
-            guard !participants.isEmpty else { continue }
             shouldUpdateLiveCallBanner(roomName: roomName, participants: participants)
         }
     }
@@ -124,10 +133,12 @@ extension NewChatViewController {
         } else {
             let activeRoomName = WindowsManager.sharedInstance.getLiveKitCallWindow()?.windowIdentifier?.liveKitRoomName
             let isAlreadyInCall = activeRoomName == roomName
+            let messageDate = liveCallRoomDates[roomName] ?? .distantPast
             chatTopView.showCallBanner(
                 roomName: roomName,
                 participants: participants,
                 callLink: callLink,
+                messageDate: messageDate,
                 isAlreadyInCall: isAlreadyInCall,
                 delegate: self
             )

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController+LiveCallBanner.swift
@@ -38,7 +38,7 @@ extension NewChatViewController: ActiveCallBannerDelegate {
 
         installActiveCallBannerIfNeeded()
 
-        let callMessages = TransactionMessage.getRecentCallMessages(for: chatId, limit: 3)
+        let callMessages = TransactionMessage.getRecentCallMessages(for: chatId)
         for callMessage in callMessages {
             guard let rawContent = callMessage.messageContent else { continue }
 

--- a/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
+++ b/com.stakwork.sphinx.desktop/Scenes/Dashboard/Chat/New Chat View Controller/NewChatViewController.swift
@@ -93,6 +93,7 @@ class NewChatViewController: DashboardSplittedViewController {
     
     // MARK: - Live call banner
     var liveCallRooms: [String: String] = [:]  // roomName -> callLink
+    var liveCallRoomDates: [String: Date] = [:]  // roomName → call message date
     
     let newMessageBubbleHelper = NewMessageBubbleHelper()
     


### PR DESCRIPTION
Generated with Hive: Fix live call banner auto-leave, rejoin subscription, join/open state, and date-ordered banner stack